### PR TITLE
GIT-44: Fix issue with circular dependencies

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,11 +38,11 @@ kernel.bin: Makefile $(OBJFILES) $(ASMOBJFILES)
 	@$(CC) -ffreestanding -O3 -nostdlib -lgcc -T kernel/arch/x86/link.ld -o kernel.bin $(filter-out $<, $^)
 	@$(info kernel.bin)
 
-%.c.o: %.c Makefile
+%.o: %.c Makefile
 	@$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 
 # TODO: fix assembly circular dependencies
-%.asm.o: %.asm Makefile
+%.o: %.asm Makefile
 	@$(AS) $(ASFLAGS) -o $@ -felf32 $<
 
 -include $(DEPFILES)


### PR DESCRIPTION
fixes #44 

resolves the issue with circular dependencies
it matched `*.asm -> *.asm.o` meaning that it would infinitely match `*.asm -> *.asm.o -> *.asm.asm.o -> etc...` 