### PR TITLE
Fix several problems with interrups

### DIFF
--- a/kernel/include/kernel/hal.h
+++ b/kernel/include/kernel/hal.h
@@ -20,6 +20,7 @@ void hal_initialize();
 void enable();
 void disable();
 void setvect(size_t intn, size_t handler);
+void irq_handler_install(uint8_t irq, void(*handler)());
 
 // outport
 void outb(uint16_t port, uint8_t val);

--- a/kernel/kernel/arch/x86/hal/hal.c
+++ b/kernel/kernel/arch/x86/hal/hal.c
@@ -11,6 +11,8 @@
 void gdt_install();
 void idt_install();
 void pic_remap();
+void isr_install();
+void irq_install();
 void pit_install();
 void idt_setvect();
 
@@ -19,6 +21,8 @@ void hal_initialize()
 	gdt_install();
 	idt_install();
 	pic_remap();
+	isr_install();
+	irq_install();
 	pit_install();
 }
 

--- a/kernel/kernel/arch/x86/hal/pit.c
+++ b/kernel/kernel/arch/x86/hal/pit.c
@@ -15,7 +15,6 @@
  */
 
 #include <kernel/hal.h>
-#include <stdio.h>
 
 /*
  * Stores tick count. Volatile uint32.
@@ -29,10 +28,10 @@ static volatile uint16_t __pitr__ = TIMER_RATE;
  */
 static void set_pit_rate(size_t hz)
 {
-    __pitr__ = (uint16_t) (1193180 / ((uint32_t) hz));
-    outb(0x43, 0x36);
-    outb(0x40, (uint8_t) (__pitr__ & 0xFF));
-    outb(0x40, (uint8_t) (__pitr__ >> 8));
+	__pitr__ = (uint16_t) (1193180 / ((uint32_t) hz));
+	outb(0x43, 0x36);
+	outb(0x40, (uint8_t) (__pitr__ & 0xFF));
+	outb(0x40, (uint8_t) (__pitr__ >> 8));
 }
 
 /*
@@ -40,7 +39,7 @@ static void set_pit_rate(size_t hz)
  */
 uint32_t get_timer_tick(void)
 {
-    return __pitc__;
+	return __pitc__;
 }
 
 /*
@@ -48,7 +47,7 @@ uint32_t get_timer_tick(void)
  */
 uint16_t get_timer_rate(void)
 {
-    return __pitr__;
+	return __pitr__;
 }
 
 /*
@@ -56,7 +55,7 @@ uint16_t get_timer_rate(void)
  */
 void pit_handler(void)
 {
-    __pitc__++;
+	__pitc__++;
 }
 
 /*
@@ -64,7 +63,7 @@ void pit_handler(void)
  */
 void pit_install(void)
 {
-    // install PIT handler to IRQ0
-    setvect(0x00, (size_t) pit_handler);
-    set_pit_rate(__pitr__);
+	// install PIT handler to IRQ0
+	irq_handler_install(0x00, (size_t) pit_handler);
+	set_pit_rate(__pitr__);
 }

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -16,11 +16,9 @@ void kernel_main()
 	terminal_install();
 	hal_initialize();
 	printf("kernel_main()\n");
-	enable();
 
-	/*while (1)
-	{
-		char* str = "         ";
-		printf("get_timer_tick() = %s\n", itoa(get_timer_tick(), str, 10));
-	}*/
+	// this will be part of pic.c probably later on
+	outb(0x21, 0b11111110);
+	outb(0xA1, 0b11111111);
+	enable();
 }


### PR DESCRIPTION
The PIT driver needed to use irq_handler_install, a function whose prototype was mising from kernel/hal.h. Also, tabs and interrupt masking, and, most importantly, actually installing the isr and irq handlers. Closes #56.