### PR TITLE
Halwork

### DIFF
--- a/kernel-build-util.sh
+++ b/kernel-build-util.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# UTILITY SCRIPT FOR BUILDING KERNEL AND RUNNING IT WITH QEMU
+
+cd kernel
+make
+cd ..
+
+cp kernel/kernel.bin sysroot/boot
+grub-mkrescue -o Carbon-x86.iso sysroot
+
+qemu-system-i386 -cdrom Carbon-x86.iso

--- a/kernel/include/kernel/hal.h
+++ b/kernel/include/kernel/hal.h
@@ -12,7 +12,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define TIMER_RATE 1000
+#define TIMER_RATE 1193
 
 void hal_initialize();
 

--- a/kernel/include/kernel/hal.h
+++ b/kernel/include/kernel/hal.h
@@ -20,6 +20,7 @@ void hal_initialize();
 void enable();
 void disable();
 void setvect(size_t intn, size_t handler);
+void irq_handler_install(uint8_t irq, void(*handler)());
 
 // outport
 void outb(uint16_t port, uint8_t val);

--- a/kernel/kernel/arch/x86/hal/hal.c
+++ b/kernel/kernel/arch/x86/hal/hal.c
@@ -11,6 +11,8 @@
 void gdt_install();
 void idt_install();
 void pic_remap();
+void isr_install();
+void irq_install();
 void pit_install();
 void idt_setvect();
 
@@ -19,6 +21,8 @@ void hal_initialize()
 	gdt_install();
 	idt_install();
 	pic_remap();
+	isr_install();
+	irq_install();
 	pit_install();
 }
 

--- a/kernel/kernel/arch/x86/hal/isr.c
+++ b/kernel/kernel/arch/x86/hal/isr.c
@@ -85,4 +85,12 @@ void isr_install()
 void isr_handler(struct hal_registers* regs)
 {
 	printf("Received isr %d, error code %x\n", regs->intn, regs->error_code);
+	printf("gs: %x  fs: %x  es: %x  ds: %x\n", regs->gs, regs->fs, regs->es, regs->ds);
+	printf("edi: %x  esi: %x  ebp: %x  esp: %x\n", regs->edi, regs->esi, regs->ebp, regs->esp);
+	printf("ebx: %x  edx: %x  ecx: %x  eax: %x\n", regs->ebx, regs->edx, regs->ecx, regs->eax);
+	printf("eip: %x\n", regs->eip);
+	printf("cs: %x\n", regs->cs);
+	printf("eflags: %x\n", regs->eflags);
+	printf("useresp: %x\n", regs->useresp);
+	printf("ss: %x\n", regs->ss);
 }

--- a/kernel/kernel/arch/x86/hal/pit.c
+++ b/kernel/kernel/arch/x86/hal/pit.c
@@ -15,7 +15,6 @@
  */
 
 #include <kernel/hal.h>
-#include <stdio.h>
 
 /*
  * Stores tick count. Volatile uint32.
@@ -29,10 +28,10 @@ static volatile uint16_t __pitr__ = TIMER_RATE;
  */
 static void set_pit_rate(size_t hz)
 {
-    __pitr__ = (uint16_t) (1193180 / ((uint32_t) hz));
-    outb(0x43, 0x36);
-    outb(0x40, (uint8_t) (__pitr__ & 0xFF));
-    outb(0x40, (uint8_t) (__pitr__ >> 8));
+	__pitr__ = (uint16_t) (1193180 / ((uint32_t) hz));
+	outb(0x43, 0x36);
+	outb(0x40, (uint8_t) (__pitr__ & 0xFF));
+	outb(0x40, (uint8_t) (__pitr__ >> 8));
 }
 
 /*
@@ -40,7 +39,7 @@ static void set_pit_rate(size_t hz)
  */
 uint32_t get_timer_tick(void)
 {
-    return __pitc__;
+	return __pitc__;
 }
 
 /*
@@ -48,7 +47,7 @@ uint32_t get_timer_tick(void)
  */
 uint16_t get_timer_rate(void)
 {
-    return __pitr__;
+	return __pitr__;
 }
 
 /*
@@ -56,7 +55,7 @@ uint16_t get_timer_rate(void)
  */
 void pit_handler(void)
 {
-    __pitc__++;
+	__pitc__++;
 }
 
 /*
@@ -64,7 +63,7 @@ void pit_handler(void)
  */
 void pit_install(void)
 {
-    // install PIT handler to IRQ0
-    setvect(0x00, (size_t) pit_handler);
-    set_pit_rate(__pitr__);
+	// install PIT handler to IRQ0
+	irq_handler_install(0x00, (size_t) pit_handler);
+	set_pit_rate(__pitr__);
 }

--- a/kernel/kernel/arch/x86/hal/pit.c
+++ b/kernel/kernel/arch/x86/hal/pit.c
@@ -15,6 +15,7 @@
  */
 
 #include <kernel/hal.h>
+#include <stdio.h>
 
 /*
  * Stores tick count. Volatile uint32.
@@ -56,6 +57,7 @@ uint16_t get_timer_rate(void)
 void pit_handler(void)
 {
 	__pitc__++;
+    //printf("Call me.\n");
 }
 
 /*

--- a/kernel/kernel/arch/x86/hal/wrappers.asm
+++ b/kernel/kernel/arch/x86/hal/wrappers.asm
@@ -285,7 +285,7 @@ irq_wrapper_0:
 	cli
 	push byte 0
 	push byte 32
-	jmp isr_wrapper
+	jmp irq_wrapper
 
 irq_wrapper_1:
 	cli

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -16,11 +16,9 @@ void kernel_main()
 	terminal_install();
 	hal_initialize();
 	printf("kernel_main()\n");
-	enable();
 
-	/*while (1)
-	{
-		char* str = "         ";
-		printf("get_timer_tick() = %s\n", itoa(get_timer_tick(), str, 10));
-	}*/
+	// this will be part of pic.c probably later on
+	outb(0x21, 0b11111110);
+	outb(0xA1, 0b11111111);
+	enable();
 }

--- a/kernel/libk/stdio/vprintf.c
+++ b/kernel/libk/stdio/vprintf.c
@@ -48,12 +48,10 @@ int vprintf(const char* format, va_list args)
 					break;
 				}
 
-				// TODO: Fix this section
-				/*
 				case 'i':
 				case 'd':
 				{
-					char buf[BUF_SIZE] = {0};
+					char buf[12] = {0};
 					terminal_print(itoa(va_arg(args, int), buf, 10));
 					res += strlen(buf);
 					break;
@@ -61,7 +59,7 @@ int vprintf(const char* format, va_list args)
 
 				case 'u':
 				{
-					char buf[BUF_SIZE] = {0};
+					char buf[12] = {0};
 					terminal_print(itoa(va_arg(args, unsigned int), buf, 10));
 					res += strlen(buf);
 					break;
@@ -70,7 +68,7 @@ int vprintf(const char* format, va_list args)
 				case 'X':
 				case 'x':
 				{
-					char buf[BUF_SIZE] = {0};
+					char buf[12] = {0};
 					terminal_print("0x");
 					res += 2;
 					terminal_print(itoa(va_arg(args, int), buf, 16));
@@ -80,7 +78,7 @@ int vprintf(const char* format, va_list args)
 
 				case 'b':
 				{
-					char buf[BUF_SIZE] = {0};
+					char buf[12] = {0};
 					terminal_print("0b");
 					res += 2;
 					terminal_print(itoa(va_arg(args, int), buf, 2));
@@ -90,7 +88,7 @@ int vprintf(const char* format, va_list args)
 
 				case 'o':
 				{
-					char buf[BUF_SIZE] = {0};
+					char buf[12] = {0};
 					putchar('0');
 					res += 1;
 					terminal_print(itoa(va_arg(args, int), buf, 8));
@@ -104,7 +102,7 @@ int vprintf(const char* format, va_list args)
 					*tmp = res;
 					break;
 				}
-				*/
+				
 
 				default:
 				{


### PR DESCRIPTION
TO ADD TO CHANGELOG:
- adds code to kernel.c main method for masking irq lines from PIC for IRQ0
- fixes #56 (issue was accidental call to isr_wrapper instead of irq_wrapper)
- changed TIMER_RATE to 1193 for now
- re-added commented-out code in libk/stdio/vprintf.c and defaulted to buffers of size 12 for internal itoa calls
- made isr_handler in kernel/kernel/hal/isr.c more verbose: now dumps all registers to terminal
- added a file (kernel-build-util.sh) for fast builds for testing
- prototyped irq_handler_install in kernel/hal.h